### PR TITLE
feat: refactor to use full types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,31 @@
 {
-    "name": "flipt/client",
-    "description": "A Flipt client to evaluate flags on a remote flipt instance",
-    "keywords": [
-        "flipt",
-        "flipt php",
-        "feature flags"
-    ],
-    "homepage": "https://github.com/legoheld/flipt-php",
-    "require": {
-        "php": ">=8.0",
-        "guzzlehttp/guzzle": "^7"
-    },
-    "require-dev": {
-        "phpunit/php-code-coverage": "^10",
-        "phpunit/phpunit": "^10"
-    },
-    "autoload": {
-        "psr-4": {
-            "Flipt\\": "src/Flipt/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Flipt\\Tests\\": "tests/"
-        }
-    },
-    "config": {
-        "sort-packages": true
+  "name": "flipt/client",
+  "description": "A Flipt client to evaluate flags on a remote flipt instance",
+  "keywords": [
+    "flipt",
+    "flipt php",
+    "feature flags"
+  ],
+  "homepage": "https://flipt.io",
+  "require": {
+    "php": ">=8.0",
+    "guzzlehttp/guzzle": "^7"
+  },
+  "require-dev": {
+    "phpunit/php-code-coverage": "^10",
+    "phpunit/phpunit": "^10"
+  },
+  "autoload": {
+    "psr-4": {
+      "Flipt\\": "src/Flipt/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Flipt\\Tests\\": "tests/"
+    }
+  },
+  "config": {
+    "sort-packages": true
+  }
 }

--- a/src/Flipt/Models/BooleanEvaluationResult.php
+++ b/src/Flipt/Models/BooleanEvaluationResult.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flipt\Models;
+
+interface BooleanEvaluationResult
+{
+    public function getEnabled(): bool;
+    public function getReason(): string;
+    public function getRequestDurationMillis(): float;
+    public function getRequestId(): string;
+    public function getTimestamp(): string;
+}

--- a/src/Flipt/Models/DefaultBooleanEvaluationResult.php
+++ b/src/Flipt/Models/DefaultBooleanEvaluationResult.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flipt\Models;
+
+use Flipt\Models\BooleanEvaluationResult;
+
+final class DefaultBooleanEvaluationResult implements BooleanEvaluationResult
+{
+    public bool $enabled;
+    public string $reason;
+    public float $requestDurationMillis;
+    public string $requestId;
+    public string $timestamp;
+
+    public function __construct(
+        bool $enabled,
+        string $reason,
+        float $requestDurationMillis,
+        string $requestId,
+        string $timestamp
+    ) {
+        $this->enabled = $enabled;
+        $this->reason = $reason;
+        $this->requestDurationMillis = $requestDurationMillis;
+        $this->requestId = $requestId;
+        $this->timestamp = $timestamp;
+    }
+
+    public function getEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+    public function getRequestDurationMillis(): float
+    {
+        return $this->requestDurationMillis;
+    }
+
+    public function getRequestId(): string
+    {
+        return $this->requestId;
+    }
+
+    public function getTimestamp(): string
+    {
+        return $this->timestamp;
+    }
+}

--- a/src/Flipt/Models/DefaultVariantEvaluationResult.php
+++ b/src/Flipt/Models/DefaultVariantEvaluationResult.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flipt\Models;
+
+use Flipt\Models\VariantEvaluationResult;
+
+final class DefaultVariantEvaluationResult implements VariantEvaluationResult
+{
+    public bool $match;
+    public string $reason;
+    public float $requestDurationMillis;
+    public string $requestId;
+    public string $timestamp;
+    public ?array $segmentKeys;
+    public ?string $variantKey;
+    public ?string $variantAttachment;
+
+    public function __construct(
+        bool $match,
+        string $reason,
+        float $requestDurationMillis,
+        string $requestId,
+        string $timestamp,
+        ?array $segmentKeys,
+        ?string $variantKey,
+        ?string $variantAttachment
+    ) {
+        $this->match = $match;
+        $this->reason = $reason;
+        $this->requestDurationMillis = $requestDurationMillis;
+        $this->requestId = $requestId;
+        $this->timestamp = $timestamp;
+        $this->segmentKeys = $segmentKeys;
+        $this->variantKey = $variantKey;
+        $this->variantAttachment = $variantAttachment;
+    }
+
+    public function getMatch(): bool
+    {
+        return $this->match;
+    }
+
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+    public function getRequestDurationMillis(): float
+    {
+        return $this->requestDurationMillis;
+    }
+
+    public function getRequestId(): string
+    {
+        return $this->requestId;
+    }
+
+    public function getTimestamp(): string
+    {
+        return $this->timestamp;
+    }
+
+    public function getSegmentKeys(): ?array
+    {
+        return $this->segmentKeys;
+    }
+
+    public function getVariantKey(): ?string
+    {
+        return $this->variantKey;
+    }
+
+    public function getVariantAttachment(): ?string
+    {
+        return $this->variantAttachment;
+    }
+}

--- a/src/Flipt/Models/VariantEvaluationResult.php
+++ b/src/Flipt/Models/VariantEvaluationResult.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flipt\Models;
+
+interface VariantEvaluationResult
+{
+    public function getMatch(): bool;
+    public function getReason(): string;
+    public function getRequestDurationMillis(): float;
+    public function getRequestId(): string;
+    public function getTimestamp(): string;
+    public function getSegmentKeys(): ?array;
+    public function getVariantKey(): ?string;
+    public function getVariantAttachment(): ?string;
+}

--- a/tests/FliptClientTest.php
+++ b/tests/FliptClientTest.php
@@ -15,67 +15,64 @@ final class FliptClientTest extends TestCase
     protected MockHandler $mockHandler;
     protected array $history;
     protected FliptClient $apiClient;
-    
-    public function setUp():void {
+
+    public function setUp(): void
+    {
 
         $this->mockHandler = new MockHandler();
-        $handlerStack = HandlerStack::create( $this->mockHandler );
+        $handlerStack = HandlerStack::create($this->mockHandler);
 
         $this->history = [];
-        $handlerStack->push( Middleware::history( $this->history ) );
+        $handlerStack->push(Middleware::history($this->history));
 
         $httpClient = new Client([
             'handler' => $handlerStack,
         ]);
 
-        $this->apiClient = new FliptClient( $httpClient, 'token', 'namespace', [ 'context' => 'demo' ], 'entityId' );
+        $this->apiClient = new FliptClient($httpClient, 'token', 'namespace', ['context' => 'demo'], 'entityId');
     }
 
 
 
-    public function testContextMerge(): void {
+    public function testContextMerge(): void
+    {
 
-        $this->queueResponse( [ 'enabled' => true ] );
+        $this->queueResponse(['enabled' => true, 'reason' => 'UNKNOWN_EVALUATION_REASON', 'requestDurationMillis' => 123456, 'requestId' => '621e48e2-9127-4309-b786-3bfa5885f4bc"23456789', 'requestDurationMillis' => 0.39315, 'timestamp' => '2023-10-31T00:57:47.263242143Z']);
 
-        $client2 = $this->apiClient->withContext( [ 'context1' => 'one', 'context2' => 'two' ] );
+        $client2 = $this->apiClient->withContext(['context1' => 'one', 'context2' => 'two']);
 
-        $client2->boolean('flag', [ 'user' => 'demo2', 'context1' => 'new' ] );
+        $client2->boolean('flag', ['user' => 'demo2', 'context1' => 'new']);
         $payload = $this->getLastPayload();
 
-        $this->assertEquals( $payload, [
+        $this->assertEquals($payload, [
             'flagKey' => 'flag',
             'namespaceKey' => 'namespace',
-            'context' => [ 'user' => 'demo2', 'context1' => 'new', 'context2' => 'two' ],
+            'context' => ['user' => 'demo2', 'context1' => 'new', 'context2' => 'two'],
             'entityId' => 'entityId',
         ]);
-
     }
 
 
-    public function testEntityId(): void {
+    public function testEntityId(): void
+    {
 
-        // test boolean entity request
-        $this->queueResponse( [ 'enabled' => true ] );
+        $this->queueResponse(['enabled' => true, 'reason' => 'UNKNOWN_EVALUATION_REASON', 'requestDurationMillis' => 123456, 'requestId' => '621e48e2-9127-4309-b786-3bfa5885f4bc"23456789', 'requestDurationMillis' => 0.39315, 'timestamp' => '2023-10-31T00:57:47.263242143Z']);
 
-        $result = $this->apiClient->boolean('flag', [], 'ENTITY' );
+        $result = $this->apiClient->boolean('flag', [], 'ENTITY');
 
         $payload = $this->getLastPayload();
-        $this->assertEquals( $payload, [
+        $this->assertEquals($payload, [
             'flagKey' => 'flag',
             'namespaceKey' => 'namespace',
-            'context' => [ 'context' => 'demo' ],
+            'context' => ['context' => 'demo'],
             'entityId' => 'ENTITY',
         ]);
-
-        
     }
 
-    
+
     public function testBoolean(): void
     {
-        
-        // specify the request response for the next call
-        $this->queueResponse( [ 'enabled' => true ] );
+        $this->queueResponse(['enabled' => true, 'reason' => 'MATCH_EVALUATION_REASON', 'requestDurationMillis' => 123456, 'requestId' => '621e48e2-9127-4309-b786-3bfa5885f4bc"23456789', 'requestDurationMillis' => 0.39315, 'timestamp' => '2023-10-31T00:57:47.263242143Z']);
 
         // execute the client function
         $result = $this->apiClient->boolean('flag');
@@ -83,27 +80,25 @@ final class FliptClientTest extends TestCase
         // get payload on request to validate
         $payload = $this->getLastPayload();
 
-        $this->assertEquals( $payload, [
+        $this->assertEquals($payload, [
             'flagKey' => 'flag',
             'namespaceKey' => 'namespace',
-            'context' => [ 'context' => 'demo' ],
+            'context' => ['context' => 'demo'],
             'entityId' => 'entityId',
         ]);
 
-        $this->assertTrue( $result );
-
-
-        // test false 
-        $this->queueResponse( [ 'enabled' => false ] );
-        $result = $this->apiClient->boolean('flag');
-        $this->assertFalse( $result );
+        $this->assertTrue($result->getEnabled());
+        $this->assertEquals($result->getReason(), 'MATCH_EVALUATION_REASON');
+        $this->assertEquals($result->getRequestDurationMillis(), 0.39315);
+        $this->assertEquals($result->getRequestId(), '621e48e2-9127-4309-b786-3bfa5885f4bc"23456789');
+        $this->assertEquals($result->getTimestamp(), '2023-10-31T00:57:47.263242143Z');
     }
 
 
     public function testVariant(): void
     {
-        
-        $this->queueResponse( [ 'match' => true, 'variantKey' => 'A' ] );
+
+        $this->queueResponse(['match' => true, 'reason' => 'MATCH_EVALUATION_REASON', 'requestDurationMillis' => 123456, 'requestId' => '621e48e2-9127-4309-b786-3bfa5885f4bc"23456789', 'requestDurationMillis' => 0.39315, 'timestamp' => '2023-10-31T00:57:47.263242143Z', 'segmentKeys' => ['foo', 'bar'], 'variantKey' => 'A', 'variantAttachment' => "{'data':'attachment'}"]);
 
         // execute the client function
         $result = $this->apiClient->variant('flag');
@@ -111,57 +106,30 @@ final class FliptClientTest extends TestCase
         // get payload on request to validate
         $payload = $this->getLastPayload();
 
-        $this->assertEquals( $payload, [
+        $this->assertEquals($payload, [
             'flagKey' => 'flag',
             'namespaceKey' => 'namespace',
-            'context' => [ 'context' => 'demo' ],
+            'context' => ['context' => 'demo'],
             'entityId' => 'entityId',
         ]);
 
-        $this->assertEquals( $result, 'A' );
-        
-        
-        $this->queueResponse( [ 'match' => true, 'variantKey' => 'B' ] );
-        $result = $this->apiClient->variant('flag');
-        $this->assertEquals( $result, 'B' );
-
+        $this->assertTrue($result->getMatch());
+        $this->assertEquals($result->getReason(), 'MATCH_EVALUATION_REASON');
+        $this->assertEquals($result->getRequestDurationMillis(), 0.39315);
+        $this->assertEquals($result->getRequestId(), '621e48e2-9127-4309-b786-3bfa5885f4bc"23456789');
+        $this->assertEquals($result->getTimestamp(), '2023-10-31T00:57:47.263242143Z');
+        $this->assertEquals($result->getSegmentKeys(), ['foo', 'bar']);
+        $this->assertEquals($result->getVariantKey(), 'A');
+        $this->assertEquals($result->getVariantAttachment(), "{'data':'attachment'}");
     }
 
-
-    public function testVariantAttachment(): void
+    protected function getLastPayload()
     {
-        
-        $this->queueResponse( [ 'match' => true, 'variantAttachment' => '{"demo":"json"}' ] );
-
-        // execute the client function
-        $result = $this->apiClient->variantAttachment('flag');
-
-        // get payload on request to validate
-        $payload = $this->getLastPayload();
-
-        $this->assertEquals( $payload, [
-            'flagKey' => 'flag',
-            'namespaceKey' => 'namespace',
-            'context' => [ 'context' => 'demo' ],
-            'entityId' => 'entityId',
-        ]);
-
-        $this->assertEquals( $result, [ 'demo' => 'json' ] );
-        
-        
-        $this->queueResponse( [ 'match' => true, 'variantAttachment' => '{"demo2":"json2"}' ] );
-        $result = $this->apiClient->variantAttachment('flag');
-        $this->assertEquals( $result, [ 'demo2' => 'json2' ] );
+        return json_decode($this->history[0]['request']->getBody()->getContents(), true);
     }
 
-
-
-    protected function getLastPayload() {
-        return json_decode( $this->history[0]['request']->getBody()->getContents(), true );
+    protected function queueResponse(array $response)
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode($response)));
     }
-
-    protected function queueResponse( array $response ) {
-        $this->mockHandler->append(new Response(200, [], json_encode( $response )));
-    }
-
 }


### PR DESCRIPTION
refactor to use classes for `XEvaluationResults`

this is more inline with our other Java/Python/Go SDK to return the full response type to the caller

in the OpenFeature SDK we can scope down the returns to return the value specified (ie: `resolveBooleanValue`, `resolveStringValue`, etc

cc @legoheld